### PR TITLE
Add mmark generation utility

### DIFF
--- a/flatten/Cargo.lock
+++ b/flatten/Cargo.lock
@@ -244,8 +244,20 @@ dependencies = [
  "arrayvec",
  "clap",
  "kurbo",
+ "rand",
  "roxmltree",
  "skia-safe",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -394,6 +406,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +437,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -643,6 +691,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"

--- a/flatten/Cargo.toml
+++ b/flatten/Cargo.toml
@@ -12,4 +12,4 @@ arrayvec = "0.7.1"
 clap = { version = "4.5.4", features = ["derive"] }
 roxmltree = "0.19.0"
 skia-safe = { version = "0.72.0", optional = true }
-
+rand = "0.8.5"

--- a/flatten/README.md
+++ b/flatten/README.md
@@ -1,0 +1,29 @@
+# Test crate
+
+## mmark
+
+A simple utility to generate a static instance of the mmark test scene.
+
+Usage: `cargo run mmark {n} > mmark.svg`
+
+## prim-count-graph
+
+For timing graphs:
+
+```
+cargo run --release --features skia-safe prim-count-graph {directory} timing
+```
+
+Result is in gnuplot format, sent to stdout.
+
+For primitive count graphs:
+
+```
+cargo run --release --features skia-safe prim-count-graph {directory} count
+```
+
+Result is in gnuplot format, sent to stdout.
+
+Currently this runs arcs, lines and the Skia stroker.
+
+## TODO: other subcommands

--- a/flatten/src/main.rs
+++ b/flatten/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Vello Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{Arg, Parser};
+use clap::Parser;
 use cubic32::{Cubic, Point};
 use euler32::CubicToEulerIter;
 use flatten::{espc_integral_inv, n_subdiv_analytic};
@@ -17,6 +17,7 @@ mod euler_arc;
 mod evolute;
 mod flatten;
 mod flatten32;
+mod mmark;
 mod perf_graph;
 #[cfg(feature = "skia-safe")]
 mod skia;
@@ -30,6 +31,7 @@ enum Args {
     Evolute,
     Espc,
     EstFlattenErr,
+    Mmark(mmark::MmarkArgs),
     PrimCountGraph(perf_graph::PrimCountArgs),
     Stroke,
     Svg(svg::SvgArgs),
@@ -106,6 +108,7 @@ fn main() {
         Args::Espc => main_espc(),
         Args::EstFlattenErr => main_est_flatten_err(),
         Args::Evolute => evolute::euler_evolute_main(),
+        Args::Mmark(args) => mmark::mmark_main(args),
         Args::PrimCountGraph(args) => perf_graph::perf_graph(args),
         Args::Stroke => stroke::stroke_main(),
         Args::Svg(args) => svg::svg_main(args),

--- a/flatten/src/mmark.rs
+++ b/flatten/src/mmark.rs
@@ -1,0 +1,188 @@
+// Copyright 2023 the Vello Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A benchmark based on MotionMark 1.2's path benchmark.
+//! This is roughly comparable to:
+//!
+//! <https://browserbench.org/MotionMark1.2/developer.html?warmup-length=2000&warmup-frame-count=30&first-frame-minimum-length=0&test-interval=15&display=minimal&tiles=big&controller=adaptive&frame-rate=50&time-measurement=performance&suite-name=MotionMark&test-name=Paths&complexity=1>
+
+use std::cmp::Ordering;
+
+use clap::Parser;
+use rand::seq::SliceRandom;
+use rand::Rng;
+use kurbo::{BezPath, CubicBez, Line, ParamCurve, PathSeg, Point, QuadBez};
+
+const WIDTH: usize = 1600;
+const HEIGHT: usize = 900;
+
+const GRID_WIDTH: i64 = 80;
+const GRID_HEIGHT: i64 = 40;
+
+#[derive(Parser)]
+pub struct MmarkArgs {
+    n: usize,
+}
+
+pub struct MMark {
+    elements: Vec<Element>,
+}
+
+struct Element {
+    seg: PathSeg,
+    color: &'static str,
+    width: f64,
+    is_split: bool,
+    grid_point: GridPoint,
+}
+
+#[derive(Clone, Copy)]
+struct GridPoint(i64, i64);
+
+impl MMark {
+    pub fn new(n: usize) -> MMark {
+        let mut result = MMark { elements: vec![] };
+        result.resize(n);
+        result
+    }
+
+    fn resize(&mut self, n: usize) {
+        let old_n = self.elements.len();
+        match n.cmp(&old_n) {
+            Ordering::Less => self.elements.truncate(n),
+            Ordering::Greater => {
+                let mut last = self
+                    .elements
+                    .last()
+                    .map(|e| e.grid_point)
+                    .unwrap_or(GridPoint(GRID_WIDTH / 2, GRID_HEIGHT / 2));
+                self.elements.extend((old_n..n).map(|_| {
+                    let element = Element::new_rand(last);
+                    last = element.grid_point;
+                    element
+                }));
+            }
+            _ => (),
+        }
+    }
+
+    fn render(&mut self) {
+        let width = 2048;
+        let height = 1536;
+        println!("<svg width=\"{width}\" height=\"{height}\" viewBox=\"0 0 {width} {height}\" xmlns=\"http://www.w3.org/2000/svg\">");
+        let mut rng = rand::thread_rng();
+        let mut path = BezPath::new();
+        let len = self.elements.len();
+        for (i, element) in self.elements.iter_mut().enumerate() {
+            if path.is_empty() {
+                path.move_to(element.seg.start());
+            }
+            match element.seg {
+                PathSeg::Line(l) => path.line_to(l.p1),
+                PathSeg::Quad(q) => path.quad_to(q.p1, q.p2),
+                PathSeg::Cubic(c) => path.curve_to(c.p1, c.p2, c.p3),
+            }
+            if element.is_split || i == len {
+                // This gets color and width from the last element, original
+                // gets it from the first, but this should not matter.
+                println!("  <path d=\"{}\" stroke-width=\"{}\" stroke=\"{}\" fill=\"none\" />",
+                    path.to_svg(), element.width, element.color
+                );
+                path.truncate(0); // Should have clear method, to avoid allocations.
+            }
+            if rng.gen::<f32>() > 0.995 {
+                element.is_split ^= true;
+            }
+        }
+        println!("</svg>");
+    }
+}
+
+const COLORS: &[&str] = &[
+    "#101010",
+    "#808080",
+    "#c0c0c0",
+    "#101010",
+    "#808080",
+    "#c0c0c0",
+    "#e01040",
+];
+
+impl Element {
+    fn new_rand(last: GridPoint) -> Element {
+        let mut rng = rand::thread_rng();
+        let seg_type = rng.gen_range(0..4);
+        let next = GridPoint::random_point(last);
+        let (grid_point, seg) = if seg_type < 2 {
+            (
+                next,
+                PathSeg::Line(Line::new(last.coordinate(), next.coordinate())),
+            )
+        } else if seg_type < 3 {
+            let p2 = GridPoint::random_point(next);
+            (
+                p2,
+                PathSeg::Quad(QuadBez::new(
+                    last.coordinate(),
+                    next.coordinate(),
+                    p2.coordinate(),
+                )),
+            )
+        } else {
+            let p2 = GridPoint::random_point(next);
+            let p3 = GridPoint::random_point(next);
+            (
+                p3,
+                PathSeg::Cubic(CubicBez::new(
+                    last.coordinate(),
+                    next.coordinate(),
+                    p2.coordinate(),
+                    p3.coordinate(),
+                )),
+            )
+        };
+        let color = *COLORS.choose(&mut rng).unwrap();
+        let width = rng.gen::<f64>().powi(5) * 20.0 + 1.0;
+        let is_split = rng.gen();
+        Element {
+            seg,
+            color,
+            width,
+            is_split,
+            grid_point,
+        }
+    }
+}
+
+const OFFSETS: &[(i64, i64)] = &[(-4, 0), (2, 0), (1, -2), (1, 2)];
+
+impl GridPoint {
+    fn random_point(last: GridPoint) -> GridPoint {
+        let mut rng = rand::thread_rng();
+
+        let offset = OFFSETS.choose(&mut rng).unwrap();
+        let mut x = last.0 + offset.0;
+        if !(0..=GRID_WIDTH).contains(&x) {
+            x -= offset.0 * 2;
+        }
+        let mut y = last.1 + offset.1;
+        if !(0..=GRID_HEIGHT).contains(&y) {
+            y -= offset.1 * 2;
+        }
+        GridPoint(x, y)
+    }
+
+    fn coordinate(&self) -> Point {
+        let scale_x = WIDTH as f64 / ((GRID_WIDTH + 1) as f64);
+        let scale_y = HEIGHT as f64 / ((GRID_HEIGHT + 1) as f64);
+        Point::new(
+            (self.0 as f64 + 0.5) * scale_x,
+            100.0 + (self.1 as f64 + 0.5) * scale_y,
+        )
+    }
+}
+
+pub fn mmark_main(args: MmarkArgs) {
+    let mut mmark = MMark::new(args.n);
+    mmark.render();
+}


### PR DESCRIPTION
Creates an svg file, which can then be run through the prim-count-graph utility. Also starts a skeletal README.