### PR TITLE
Re-anonymize authors

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -6,14 +6,14 @@
 \setcitestyle{authoryear}
 \begin{document}
 \title{GPU-friendly Stroke Expansion}
-\author{Raph Levien}
-\author{Arman Uguray}
-\affiliation{
-    \institution{Google}
-    \city{San Francisco}
-    \state{CA}
-    \country{USA}
-}
+\author{Anonymous Author 1}
+\author{Anonymous Author 2}
+%\affiliation{
+%    \institution{Google}
+%    \city{San Francisco}
+%    \state{CA}
+%    \country{USA}
+%}
 \begin{CCSXML}
     <ccs2012>
        <concept>


### PR DESCRIPTION
Submission of the revised version is also anonymous, so hide authors and affiliations. We'll revert this later.

Only including the .tex change, including the pdf would make it harder to revert.