### PR TITLE
docs: Fix beztoy resource URLs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -150,8 +150,8 @@
     </p>
   </div>
   <script type="module">
-    import init, * as bindings from '/beztoy.js';
-    init('/beztoy_bg.wasm');
+    import init, * as bindings from '/gpu-stroke-expansion-paper/beztoy.js';
+    init('/gpu-stroke-expansion-paper/beztoy_bg.wasm');
   </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -150,8 +150,8 @@
     </p>
   </div>
   <script type="module">
-    import init, * as bindings from '/gpu-stroke-expansion-paper/beztoy.js';
-    init('/gpu-stroke-expansion-paper/beztoy_bg.wasm');
+    import init, * as bindings from './beztoy.js';
+    init('./beztoy_bg.wasm');
   </script>
 </body>
 </html>


### PR DESCRIPTION
The Beztoy demo doesn't work in the deployed page as it can't find beztoy.js. The site is deployed at
https://linebender.org/gpu-stroke-expansion-paper. When fetching '/beztoy.js' and '/beztoy_bg.wasm', the requests go to https://linebender.org/beztoy.js.

~~Let's explicitly spell out the paper repo URL to fix the demo, which matches what the linebender.org/vello deployment does (see [here](https://github.com/linebender/vello/blob/94ce032d53f3ec48d90e7bbbdf739aaae8a40714/.github/workflows/web-demo.yml#L43)).~~  Trying out relative paths instead. Those seem to work based on a test here: https://armansito.github.io/gpu-stroke-expansion-paper/. 